### PR TITLE
Fix Vite build to use client as root

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -14,6 +14,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/client/src/main.tsx"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,14 +7,14 @@ import { fileURLToPath } from 'url'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
+  root: path.resolve(__dirname, 'client'),
+  publicDir: path.resolve(__dirname, 'client/public'),
   plugins: [react()],
   build: {
-    minify: 'terser',
-    terserOptions: {
-      compress: {
-        drop_console: true,
-        drop_debugger: true
-      }
+    outDir: path.resolve(__dirname, 'dist/client'),
+    minify: 'esbuild',
+    esbuild: {
+      drop: ['console', 'debugger']
     },
     rollupOptions: {
       output: {
@@ -29,7 +29,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './client/src')
+      '@': path.resolve(__dirname, 'client/src')
     }
   }
 })


### PR DESCRIPTION
## Summary
- point Vite to the `client` folder and output built assets under `dist/client`
- adjust HTML entry script path for the new Vite root

## Testing
- `npm run check`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689fc4fa26f48332abfe9f1faa24c42c